### PR TITLE
add budo and garnish as dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "devDependencies": {
     "a-big-triangle": "^1.0.2",
     "browserify": "^10.2.4",
+    "budo": "^5.1.5",
+    "garnish": "^3.2.1",
     "gl-shader": "^4.0.5",
     "gl-texture2d": "^2.0.9",
     "glslify": "^2.2.1",


### PR DESCRIPTION
Got some errors while trying to run the demo.

```
panzani glsl-fxaa$ npm start

> glsl-fxaa@3.0.0 start /Users/bsergean/src/glsl-fxaa
> budo demo/index.js:bundle.js --dir demo --live --verbose -- -t glslify | garnish

sh: garnish: command not found
sh: budo: command not found
```

 Those got fixed after I ran `npm install budo garnish --save-dev`
